### PR TITLE
pass fields def down to each form builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-formbuilder",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "repository": "teamious/FormBuilder",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-formbuilder",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "repository": "teamious/FormBuilder",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/components/FormBuilder.tsx
+++ b/src/components/FormBuilder.tsx
@@ -163,14 +163,18 @@ export class FormBuilder extends React.Component<IFormBuilderProps, IFormBuilder
             console.warn('Field defintion is not registered: ' + field.type);
             return;
         }
-        const component = React.createElement(fieldDef.builder, {
+
+        const fieldBuilderProps: data.IFieldBuilderProps = {
             field,
+            fields: this.props.fields,
             index,
             registry: this.props.registry,
             onFieldEditing: this.props.onFieldEditing,
             onChange: this.onFieldChanged,
             onBeforeAddField: this.props.onBeforeAddField,
-        });
+        }
+
+        const component = React.createElement(fieldDef.builder, fieldBuilderProps);
 
         const isEditing = (field === this.state.editingField);
 

--- a/src/data/IFieldBuilder.tsx
+++ b/src/data/IFieldBuilder.tsx
@@ -3,6 +3,8 @@ import { FieldRegistry } from './FieldRegistry';
 
 export interface IFieldBuilderProps {
     field: IField;
+    // The fields of the current form. Look up field key in order to build relationship with the current field. 
+    fields: IField[];
     index: number;
     registry: FieldRegistry;
     onChange: (field: IField, index: number) => void;


### PR DESCRIPTION
By passing the fields def down to form builder, so that field can build relationship with other fields.