### PR TITLE
Provide change context when onChange event happens

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,6 @@
   "name": "form-fe-docs",
   "version": "1.0.0",
   "dependencies": {
-    "@types/node": "^7.0.8",
     "css-loader": "^0.27.3",
     "file-loader": "^0.10.1",
     "node-sass": "^4.5.0",
@@ -17,6 +16,7 @@
     "url-loader": "^0.5.8"
   },
   "devDependencies": {
+    "@types/node": "^7.0.8",
     "@types/object-assign": "^4.0.30",
     "@types/react": "^15.0.21",
     "@types/react-bootstrap": "0.0.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-formbuilder",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "repository": "teamious/FormBuilder",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/components/FormBuilder.tsx
+++ b/src/components/FormBuilder.tsx
@@ -13,14 +13,8 @@ export interface IFormBuilderProps {
     // uses this map to render the control.
     registry: data.FieldRegistry;
 
-    // onChange is called whenever the user has reordered fields to the editor via drag and drop.
-    onChange: (fields: data.IField[]) => void;
-
-    // onAddField is called when the user adds a new field.
-    onAddField: (fields: data.IField[], newField: data.IField) => void;
-
-    // onDeleteField is called when the user deletes a field.
-    onDeleteField: (fields: data.IField[], deletedField: data.IField) => void;
+    // onChange is called wheneven user changes all settings of all fields.
+    onChange: (fields: data.IField[], change: data.IFieldChange) => void;
 
     // fieldEditing is called when the user want to edit field options.
     onFieldEditing: (field: data.IField, fieldContext: data.IFieldContext, done: (field: data.IField) => void) => void;
@@ -102,7 +96,10 @@ export class FormBuilder extends React.Component<IFormBuilderProps, IFormBuilder
             this.setState({ editingField: null });
         }
         fields.splice(index, 1);
-        this.props.onDeleteField(fields, field);
+        this.props.onChange(fields, {
+            action: data.FieldAction.Delete,
+            source: field
+        });
     }
 
     // onDrop is called whenever a field is dropped on a <Droppable> component.
@@ -150,13 +147,16 @@ export class FormBuilder extends React.Component<IFormBuilderProps, IFormBuilder
             fields.splice(source.index, 1);
             fields.splice(target.index, 0, sourceField)
         }
-        this.props.onAddField(fields, sourceField);
+        this.props.onChange(fields, {
+            action: data.FieldAction.Add,
+            source: sourceField
+        });
     }
 
-    private onFieldChanged(field: data.IField, index: number) {
+    private onFieldChanged(field: data.IField, index: number, change: data.IFieldChange) {
         let fields = this.props.fields.slice();
         fields[index] = field;
-        this.props.onChange(fields);
+        this.props.onChange(fields, change);
     }
 
     // renderField takes the field.type to be rendered and looks up the

--- a/src/components/FormBuilder.tsx
+++ b/src/components/FormBuilder.tsx
@@ -13,9 +13,14 @@ export interface IFormBuilderProps {
     // uses this map to render the control.
     registry: data.FieldRegistry;
 
-    // onChange is called whenever the user has reordered or added
-    // fields to the editor via drag and drop.
+    // onChange is called whenever the user has reordered fields to the editor via drag and drop.
     onChange: (fields: data.IField[]) => void;
+
+    // onAddField is called when the user adds a new field.
+    onAddField: (fields: data.IField[], newField: data.IField) => void;
+
+    // onDeleteField is called when the user deletes a field.
+    onDeleteField: (fields: data.IField[], deletedField: data.IField) => void;
 
     // fieldEditing is called when the user want to edit field options.
     onFieldEditing: (field: data.IField, fieldContext: data.IFieldContext, done: (field: data.IField) => void) => void;
@@ -97,7 +102,7 @@ export class FormBuilder extends React.Component<IFormBuilderProps, IFormBuilder
             this.setState({ editingField: null });
         }
         fields.splice(index, 1);
-        this.props.onChange(fields);
+        this.props.onDeleteField(fields, field);
     }
 
     // onDrop is called whenever a field is dropped on a <Droppable> component.
@@ -145,7 +150,7 @@ export class FormBuilder extends React.Component<IFormBuilderProps, IFormBuilder
             fields.splice(source.index, 1);
             fields.splice(target.index, 0, sourceField)
         }
-        this.props.onChange(fields);
+        this.props.onAddField(fields, sourceField);
     }
 
     private onFieldChanged(field: data.IField, index: number) {

--- a/src/components/FormBuilder.tsx
+++ b/src/components/FormBuilder.tsx
@@ -13,7 +13,7 @@ export interface IFormBuilderProps {
     // uses this map to render the control.
     registry: data.FieldRegistry;
 
-    // onChange is called wheneven user changes all settings of all fields.
+    // onChange is called wheneven user changes any settings of fields.
     onChange: (fields: data.IField[], change: data.IFieldChange) => void;
 
     // fieldEditing is called when the user want to edit field options.

--- a/src/components/NestedForm/NestedFormBuilder.tsx
+++ b/src/components/NestedForm/NestedFormBuilder.tsx
@@ -14,10 +14,10 @@ export class NestedFormBuilder extends React.PureComponent<data.IFieldBuilderPro
         this.onBeforeAddField = this.onBeforeAddField.bind(this);
     }
 
-    private onChangeFields(fields: data.IField[]) {
+    private onChangeFields(fields: data.IField[], change: data.IFieldChange) {
         let field = assign({}, this.props.field);
         field.fields = fields;
-        this.props.onChange(field, this.props.index);
+        this.props.onChange(field, this.props.index, change);
     }
 
     private onBeforeAddField(field: data.IField): boolean {

--- a/src/data/IFieldBuilder.ts
+++ b/src/data/IFieldBuilder.ts
@@ -2,6 +2,7 @@ import { IField } from './IField';
 import { IFieldContext } from './IFieldContext';
 import { FieldRegistry } from './FieldRegistry';
 import { IEditableControlSource } from './IEditableControlSource';
+import { IFieldChange } from './IFieldChange';
 
 export interface IFieldBuilderProps {
     field: IField;
@@ -9,7 +10,7 @@ export interface IFieldBuilderProps {
     registry: FieldRegistry;
     editButton?: IEditableControlSource;
     deleteButton?: IEditableControlSource;
-    onChange: (field: IField, index: number) => void;
+    onChange: (field: IField, index: number, change: IFieldChange) => void;
     onFieldEditing: (field: IField, editingContext: IFieldContext, done: (field: IField) => void) => void;
     onBeforeAddField: (field: IField) => boolean;
 }

--- a/src/data/IFieldChange.ts
+++ b/src/data/IFieldChange.ts
@@ -1,0 +1,12 @@
+import { IField } from './IField';
+
+export enum FieldAction {
+    Change,
+    Add,
+    Delete
+}
+
+export interface IFieldChange {
+    action: FieldAction,
+    source: IField,
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -7,6 +7,7 @@ export * from './IFieldInput';
 export * from './FieldRegistry';
 export * from './IFieldDisplay';
 export * from './IFieldContext';
+export * from './IFieldChange';
 export * from './IEditableControlSource';
 
 export const FORM_BUILDER_FIELD = 'FORM_BUILDER_FIELD'


### PR DESCRIPTION
I didn't provide onAddField and onDeleteField, because
1. When handling the nested form onAddField and onDeleteField, it becomes confusing and hard to communicate with root form.
2. interface change will cause lots of build breaks.