### PR TITLE
get rid of done callback of the editing field

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "react": "15.4.1",
     "react-bootstrap": "^0.30.8",
     "react-dom": "15.4.1",
-    "react-dynamic-formbuilder": "^1.0.27",
+    "react-dynamic-formbuilder": "^1.0.28",
     "react-router": "^4.0.0",
     "react-router-dom": "^4.0.0",
     "sass-loader": "^6.0.3",

--- a/docs/src/components/DemoPage.tsx
+++ b/docs/src/components/DemoPage.tsx
@@ -21,14 +21,11 @@ import { FieldRegistry } from './constants';
 interface IState {
     fields: IField[],
     editingField: IField,
-    editingContext: IFieldContext;
     value: any,
     formState: IFormState,
 }
 
 class DemoPage extends React.Component<void, IState> {
-    private fieldEdited: (field: IField) => void;
-
     constructor() {
         super()
         this.onChangeFields = this.onChangeFields.bind(this);
@@ -40,15 +37,13 @@ class DemoPage extends React.Component<void, IState> {
         this.state = {
             fields: [],
             editingField: null,
-            editingContext: null,
             value: {},
             formState: {},
         };
     }
 
-    private onFieldEditing(field: IField, fieldContext: IFieldContext, done: (field: IField) => void) {
-        this.setState({ editingField: field, editingContext: fieldContext } as IState);
-        this.fieldEdited = done;
+    private onFieldEditing(field: IField) {
+        this.setState({ editingField: field} as IState);
     }
 
     private onDeleteField(fields: IField[]) {
@@ -59,9 +54,8 @@ class DemoPage extends React.Component<void, IState> {
         this.setState({ fields } as IState);
     }
 
-    private onFieldOptionChanged(field: IField) {
-        this.setState({ editingField: field } as IState);
-        this.fieldEdited(field);
+    private onFieldOptionChanged(field: IField, fields: IField[]) {
+        this.setState({ editingField: field, fields } as IState);
     }
 
     private onValueChanged(value: any, formState: IFormState) {
@@ -111,7 +105,7 @@ class DemoPage extends React.Component<void, IState> {
                                 <FieldOptionEditor
                                     registry={FieldRegistry}
                                     field={this.state.editingField}
-                                    fieldContext={this.state.editingContext}
+                                    fields={this.state.fields}
                                     onChange={this.onFieldOptionChanged}
                                 />
                             </Panel>

--- a/docs/src/components/snippets/FieldOptionEditor.tsx
+++ b/docs/src/components/snippets/FieldOptionEditor.tsx
@@ -3,13 +3,13 @@ import { Modal, Button } from 'react-bootstrap';
 import SingleSelector from '../fields/SingleSelector';
 import SingleSelectorOptionEditor from '../fields/SingleSelectorOptionEditor';
 import SingleLineTextField from '../fields/SingleLineTextField';
-import SingleLineTextFieldOptionEditor from '../fields/SingleLineTextFieldOptionEditor'
+import SingleLineTextFieldOptionEditor from '../fields/SingleLineTextFieldOptionEditor';
 import {
     FieldOptionEditor,
     FormBuilder,
     IField,
     IFieldContext,
-    FieldRegistry
+    FieldRegistry,
 } from 'react-dynamic-formbuilder';
 
 
@@ -93,18 +93,16 @@ export default class MyApp extends React.Component<{}, IState> {
         this.setState({ fields } as IState);
     }
 
-    private onChangeField(field: IField) {
-        this.setState({ field } as IState);
-        this.callback(field);
+    private onChangeField(field: IField, fields: IField[]) {
+        this.setState({ field, fields } as IState);
     }
 
     private closeModal() {
         this.setState({ field: null } as IState);
     }
 
-    private onFieldEditing(field: IField, editingContext: IFieldContext, callback: (field: IField) => void) {
-        this.setState({ field, editingContext } as IState);
-        this.callback = callback;
+    private onFieldEditing(field: IField) {
+        this.setState({ field } as IState);
     }
 
     render() {
@@ -116,7 +114,7 @@ export default class MyApp extends React.Component<{}, IState> {
                             onChange={this.onChangeField}
                             registry={registry}
                             field={this.state.field}
-                            fieldContext={this.state.editingContext}
+                            fields={this.state.fields}
                         />
                     </Modal.Body>
                     <Modal.Footer>

--- a/docs/src/components/snippets/FormBuilder.tsx
+++ b/docs/src/components/snippets/FormBuilder.tsx
@@ -86,7 +86,7 @@ export default class extends React.Component<IProps, IState> {
         }
     }
 
-    private onFieldEditing(field: IField, editingContext: IFieldContext, callback: (field: IField) => void) {
+    private onFieldEditing(field: IField) {
         // Do nothing for this example
         this.setState({field} as IState);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-formbuilder",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "repository": "teamious/FormBuilder",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/components/FieldOptionEditor.tsx
+++ b/src/components/FieldOptionEditor.tsx
@@ -6,7 +6,7 @@ export interface IFieldOptionEditorComponentProps {
     field: data.IField;
     fields: Array<data.IField>;
     registry: data.FieldRegistry;
-    onChange: (editedField: data.IField, fields: data.IField[], change: data.IFieldChange) => void;
+    onChange: (editedField: data.IField, fields: data.IField[]) => void;
 }
 
 export interface IFieldOptionEditorState { }
@@ -49,9 +49,11 @@ export class FieldOptionEditor extends React.PureComponent<IFieldOptionEditorCom
 
     private onOptionChanged(field: data.IField) {
         const fields = util.updateField(this.props.field, field, this.props.fields);
-        this.props.onChange(field, fields, {
-            action: data.FieldAction.Change,
-            source: field
-        });
+        if (!fields) {
+            console.warn('cannot update field inside fields.', this.props.field, this.props.fields);
+        }
+        else {
+            this.props.onChange(field, fields);
+        }
     }
 }

--- a/src/components/FieldOptionEditor.tsx
+++ b/src/components/FieldOptionEditor.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import * as data from '../data/';
+import * as util from '../utils';
 
 export interface IFieldOptionEditorComponentProps {
     field: data.IField;
-    fieldContext: data.IFieldContext;
+    fields: Array<data.IField>;
     registry: data.FieldRegistry;
-    onChange: (field: data.IField) => void;
+    onChange: (editedField: data.IField, fields: data.IField[], change: data.IFieldChange) => void;
 }
 
 export interface IFieldOptionEditorState { }
@@ -28,10 +29,14 @@ export class FieldOptionEditor extends React.PureComponent<IFieldOptionEditorCom
             return <div />;
         }
 
-        const optionEditorProps: data.IFieldOptionEditorProps = { 
+        const context = {
+            fields: util.getFieldSiblings(field, this.props.fields)
+        };
+
+        const optionEditorProps: data.IFieldOptionEditorProps = {
             field,
-            fieldContext: this.props.fieldContext,
-            onChange: this.onOptionChanged 
+            fieldContext: context,
+            onChange: this.onOptionChanged
         };
 
         const component = React.createElement(fieldDef.editor, optionEditorProps);
@@ -43,6 +48,10 @@ export class FieldOptionEditor extends React.PureComponent<IFieldOptionEditorCom
     }
 
     private onOptionChanged(field: data.IField) {
-        this.props.onChange(field);
+        const fields = util.updateField(this.props.field, field, this.props.fields);
+        this.props.onChange(field, fields, {
+            action: data.FieldAction.Change,
+            source: field
+        });
     }
 }

--- a/src/components/FormBuilder.tsx
+++ b/src/components/FormBuilder.tsx
@@ -17,7 +17,7 @@ export interface IFormBuilderProps {
     onChange: (fields: data.IField[], change: data.IFieldChange) => void;
 
     // fieldEditing is called when the user want to edit field options.
-    onFieldEditing: (field: data.IField, fieldContext: data.IFieldContext, done: (field: data.IField) => void) => void;
+    onFieldEditing: (field: data.IField) => void;
 
     // onBeforeAddField is called before add the new field into the array.
     // If this method returns false, onChange will not be called.
@@ -71,15 +71,7 @@ export class FormBuilder extends React.Component<IFormBuilderProps, IFormBuilder
             return;
         }
 
-        this.props.onFieldEditing(field, { fields: this.props.fields }, (field: data.IField) => {
-            const editingIndex = this.props.fields.indexOf(this.props.editingField);
-            let fields = this.props.fields.slice();
-            fields[editingIndex] = field;
-            this.props.onChange(fields, {
-                action: data.FieldAction.Change,
-                source: field
-            });
-        });
+        this.props.onFieldEditing(field);
     }
 
     // onDeleteField is called when the user wants to delete a field.

--- a/src/components/NestedForm/NestedFormBuilder.tsx
+++ b/src/components/NestedForm/NestedFormBuilder.tsx
@@ -5,9 +5,7 @@ import * as data from '../../data';
 import { NestedForm } from '.'
 import { FormBuilder } from '../FormBuilder';
 
-export interface IFieldBuilderState { }
-
-export class NestedFormBuilder extends React.PureComponent<data.IFieldBuilderProps, IFieldBuilderState> {
+export class NestedFormBuilder extends React.PureComponent<data.IFieldBuilderProps, {}> {
     constructor() {
         super();
         this.onChangeFields = this.onChangeFields.bind(this);

--- a/src/data/IFieldBuilder.ts
+++ b/src/data/IFieldBuilder.ts
@@ -12,7 +12,7 @@ export interface IFieldBuilderProps {
     deleteButton?: IEditableControlSource;
     editingField: IField;
     onChange: (field: IField, index: number, change: IFieldChange) => void;
-    onFieldEditing: (field: IField, editingContext: IFieldContext, done: (field: IField) => void) => void;
+    onFieldEditing: (field: IField) => void;
     onBeforeAddField: (field: IField) => boolean;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components';
 export * from './data';
+export * from './utils';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,46 @@
+import * as assign from 'object-assign';
+import { IField } from '../data';
+
+export function updateField(oldField: IField, newField: IField, fields: Array<IField>): Array<IField> {
+    let index = fields.indexOf(oldField);
+    if (index < 0) {
+        for (let i = 0; i < fields.length; i++) {
+            if (fields[i].fields) {
+                let nestedFields = updateField(oldField, newField, fields[i].fields);
+                if (nestedFields) {
+                    index = i;
+                    newField = assign({}, fields[i], {
+                        fields: nestedFields
+                    });
+                    break;
+                }
+            }
+        }
+    }
+
+    if (index >= 0) {
+        const newFields = fields.slice();
+        newFields[index] = newField;
+        return newFields;
+    }
+
+    return null;
+}
+
+export function getFieldSiblings(field: IField, fields: Array<IField>): Array<IField> {
+    const index = fields.indexOf(field);
+    if (index >= 0) {
+        return fields;
+    }
+
+    for (let f of fields) {
+        if (f.fields) {
+            let siblings = getFieldSiblings(field, f.fields);
+            if (siblings) {
+                return siblings;
+            }
+        }
+    }
+
+    return null;
+}


### PR DESCRIPTION
The optionEditor will take care of updating the fields as well as the nested fields. So that consumer don't need to wrong about how to connect optionEditor with formBuilder.

But each field option editor don't need to operate with fields, which should just focus on updating the options of the current field.