### PR TITLE
Allow consumer to pass context to fieldInput.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-formbuilder",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "repository": "teamious/FormBuilder",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-formbuilder",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "repository": "teamious/FormBuilder",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/components/FieldSelector.tsx
+++ b/src/components/FieldSelector.tsx
@@ -16,7 +16,11 @@ export class FieldSelector extends React.PureComponent<IFieldSelectorProps, IFie
 
     render() {
         const options = this.props.registry.getFields().map(def => {
-            const {field, displayName, type} = def;
+            const { field, displayName, type } = def;
+            if (field.isSystemField) {
+                return null;
+            }
+
             return <FieldSelectorOption field={field} key={type} label={displayName} />;
         });
         return (

--- a/src/components/FormBuilder.tsx
+++ b/src/components/FormBuilder.tsx
@@ -170,6 +170,7 @@ export class FormBuilder extends React.Component<IFormBuilderProps, {}> {
         const component = React.createElement(fieldDef.builder, fieldBuilderProps);
 
         const isEditing = (field === this.props.editingField);
+        const allowDelete = !field.isSystemField;
 
         return (
             <div className='form-builder-field' key={index}>
@@ -180,6 +181,7 @@ export class FormBuilder extends React.Component<IFormBuilderProps, {}> {
                 >
                     <Editable
                         deleteButton={this.props.deleteButton}
+                        showDeleteButton={allowDelete}
                         editButton={this.props.editButton}
                         onEdit={this.onEditField}
                         onDelete={this.onDeleteField}

--- a/src/components/FormBuilderEditable.tsx
+++ b/src/components/FormBuilderEditable.tsx
@@ -8,6 +8,7 @@ export interface IFormBuilderEditableProps {
     isEditing: boolean;
     showEditButton?: boolean;
     editButton?: data.IEditableControlSource;
+    showDeleteButton?: boolean;
     deleteButton?: data.IEditableControlSource;
     onEdit: (field: data.IField) => void;
     onDelete: (index: number) => void;
@@ -68,6 +69,10 @@ export class FormBuilderEditable extends React.Component<IFormBuilderEditablePro
     }
 
     private renderDeleteButton() {
+        if (!this.props.showDeleteButton) {
+            return null;
+        }
+
         const source = this.props.deleteButton;
 
         if (!source || typeof source === 'string') {

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -12,6 +12,9 @@ export interface IFormInputProps {
 
     value: any;
 
+    // Context provides additional context which will be passed to each form field input.
+    context?: any;
+
     // form submission attempt.
     attempt?: boolean;
 
@@ -43,17 +46,20 @@ export class FormInput extends React.PureComponent<IFormInputProps, {}> {
         }
 
         const value = this.props.value[field.id];
-        const component = React.createElement(fieldDef.input, {
+        const fieldInputProps = {
             registry: this.props.registry,
             index,
             field,
             value,
+            context: this.props.context,
             attempt: this.props.attempt,
             onValueChange: this.onValueChanged,
             ref: (input) => {
                 this.fieldInputs[index] = input
             }
-        });
+        };
+
+        const component = React.createElement(fieldDef.input, fieldInputProps);
 
         return (
             <div className='form-submission-field' key={index}>

--- a/src/components/NestedForm/NestedFormInput.tsx
+++ b/src/components/NestedForm/NestedFormInput.tsx
@@ -41,6 +41,7 @@ export class NestedFormInput extends React.PureComponent<data.IFieldInputProps, 
                 key={index}
                 index={index}
                 value={entry}
+                context={this.props.context}
                 fields={this.props.field.fields}
                 registry={this.props.registry}
                 onChange={this.onEntryValueChanged}
@@ -86,6 +87,7 @@ export class NestedFormInput extends React.PureComponent<data.IFieldInputProps, 
 interface IEntryProps {
     index: number;
     value: any;
+    context: any;
     fields: data.IField[];
     registry: data.FieldRegistry;
     onChange: (value: any, formStatus: data.IFormState, index: number) => void;
@@ -107,6 +109,7 @@ class NestedFormEntry extends React.PureComponent<IEntryProps, any> {
                     fields={this.props.fields}
                     registry={this.props.registry}
                     value={this.props.value}
+                    context={this.props.context}
                     onChange={this.onValueChanged} />
             </div>
         );

--- a/src/data/IField.ts
+++ b/src/data/IField.ts
@@ -4,7 +4,10 @@ export interface IField {
     id: string;
     hint?: string;
     options?: any;
-    fields?: Array<IField>
+    fields?: Array<IField>;
+    // This flag will decide whether the field will be on FieldSelector.
+    // The field should be created by default in the form.
+    isSystemField?: boolean;
 };
 
 export interface IGenericField<T> extends IField {

--- a/src/data/IField.ts
+++ b/src/data/IField.ts
@@ -5,7 +5,7 @@ export interface IField {
     hint?: string;
     options?: any;
     fields?: Array<IField>;
-    // This flag will decide whether the field will be on FieldSelector.
+    // This flag indicates whether the field will be on FieldSelector.
     // The field should be created by default in the form.
     isSystemField?: boolean;
 };

--- a/src/data/IFieldInput.ts
+++ b/src/data/IFieldInput.ts
@@ -12,7 +12,8 @@ export interface IFieldInputProps {
     value: any;
     // It indicates whether user has tried to submit.
     attempt: boolean;
-
+    // The context is provided by consumer.
+    context: any;
     // The callback when the value has been changed.
     onValueChange: (field: IField, value: any, fieldStatus: IFieldState) => void;
 }


### PR DESCRIPTION
This can be used to let field to get user context or other context.