### PR TITLE
FieldBuilder will take care of the rendering includes editable, dropable

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "react": "15.4.1",
     "react-bootstrap": "^0.30.8",
     "react-dom": "15.4.1",
-    "react-dynamic-formbuilder": "^1.0.35",
+    "react-dynamic-formbuilder": "^1.0.36",
     "react-router": "^4.0.0",
     "react-router-dom": "^4.0.0",
     "sass-loader": "^6.0.3",

--- a/docs/src/components/constants.ts
+++ b/docs/src/components/constants.ts
@@ -1,7 +1,7 @@
 import { SingleSelectorField } from './fields/SingleSelectorField';
 import { SingleLineField } from './fields/SingleLineField';
 import {
-    NestedFormBuilder,
+    NestedFormBuilderWrapper,
     NestedFormInput,
     NestedFormDisplay,
     NestedForm,
@@ -17,7 +17,7 @@ FieldRegistry.register({
     displayName: '明细(NestForm)',
     type: NestedForm.Type,
     input: NestedFormInput,
-    builder: NestedFormBuilder,
+    builder: NestedFormBuilderWrapper,
     display: NestedFormDisplay,
 });
 

--- a/docs/src/components/fields/SingleLineField.ts
+++ b/docs/src/components/fields/SingleLineField.ts
@@ -1,5 +1,5 @@
 import { IField, IFieldDef } from 'react-dynamic-formbuilder';
-import SingleLineTextField from './SingleLineTextField';
+import { SingleLineTextField, SingleLineTextBuilder } from './SingleLineTextField';
 import KeyValueDisplay from './KeyValueDisplay';
 import SingleLineTextFieldOptionEditor from './SingleLineTextFieldOptionEditor';
 
@@ -18,7 +18,7 @@ export const SingleLineField: IFieldDef = {
     type: Type,
     field: Field,
     displayName: '单行输入(input)',
-    builder: SingleLineTextField,
+    builder: SingleLineTextBuilder,
     input: SingleLineTextField,
     display: KeyValueDisplay,
     editor: SingleLineTextFieldOptionEditor,

--- a/docs/src/components/fields/SingleLineTextField.tsx
+++ b/docs/src/components/fields/SingleLineTextField.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { FormControl, FormGroup, ControlLabel, Col } from 'react-bootstrap';
-import { IField, IFieldBuilderProps, IFieldInputProps, IFieldInputInjector } from 'react-dynamic-formbuilder';
+import { IField, IFieldBuilderProps, IFieldInputProps, IFieldInputInjector, createFieldBuilderWrapper } from 'react-dynamic-formbuilder';
 
 interface IState {
 }
 
-export default class SingleLineTextField extends React.PureComponent<IFieldInputProps & IFieldBuilderProps, IState> implements IFieldInputInjector {
+export class SingleLineTextField extends React.PureComponent<IFieldInputProps & IFieldBuilderProps, IState> implements IFieldInputInjector {
     public static defaultProps = {
         value: ''
     } as IFieldInputProps & IFieldBuilderProps
@@ -59,3 +59,5 @@ export default class SingleLineTextField extends React.PureComponent<IFieldInput
         return null;
     }
 }
+
+export const SingleLineTextBuilder = createFieldBuilderWrapper()(SingleLineTextField);

--- a/docs/src/components/fields/SingleSelector.tsx
+++ b/docs/src/components/fields/SingleSelector.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { FormControl, FormGroup, ControlLabel, Col } from 'react-bootstrap';
-import { IField, IFieldBuilderProps, IFieldInputProps } from 'react-dynamic-formbuilder';
+import { IField, IFieldBuilderProps, IFieldInputProps, createFieldBuilderWrapper } from 'react-dynamic-formbuilder';
 
 interface IState { }
 
-export default class SingleSelector extends React.PureComponent<IFieldBuilderProps & IFieldInputProps, IState> {
+export class SingleSelector extends React.PureComponent<IFieldBuilderProps & IFieldInputProps, IState> {
     public static defaultProps = {
         value: ''
     } as IFieldInputProps & IFieldBuilderProps
@@ -42,3 +42,5 @@ export default class SingleSelector extends React.PureComponent<IFieldBuilderPro
         );
     }
 }
+
+export const SingleSelectorBuilder = createFieldBuilderWrapper()(SingleSelector);

--- a/docs/src/components/fields/SingleSelectorField.ts
+++ b/docs/src/components/fields/SingleSelectorField.ts
@@ -1,5 +1,5 @@
 import { IField, IFieldDef } from 'react-dynamic-formbuilder';
-import SingleSelector from './SingleSelector';
+import { SingleSelector, SingleSelectorBuilder } from './SingleSelector';
 import KeyValueDisplay from './KeyValueDisplay';
 import SingleSelectorOptionEditor from './SingleSelectorOptionEditor';
 
@@ -18,7 +18,7 @@ export const SingleSelectorField: IFieldDef = {
     type: Type,
     field: Field,
     displayName: '单选(selector)',
-    builder: SingleSelector,
+    builder: SingleSelectorBuilder,
     input: SingleSelector,
     display: KeyValueDisplay,
     editor: SingleSelectorOptionEditor,

--- a/docs/src/components/snippets/FieldOptionEditor.tsx
+++ b/docs/src/components/snippets/FieldOptionEditor.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Modal, Button } from 'react-bootstrap';
-import SingleSelector from '../fields/SingleSelector';
+import { SingleSelector, SingleSelectorBuilder } from '../fields/SingleSelector';
 import SingleSelectorOptionEditor from '../fields/SingleSelectorOptionEditor';
-import SingleLineTextField from '../fields/SingleLineTextField';
+import { SingleLineTextField, SingleLineTextBuilder } from '../fields/SingleLineTextField';
 import SingleLineTextFieldOptionEditor from '../fields/SingleLineTextFieldOptionEditor';
 import {
     FieldOptionEditor,
@@ -32,7 +32,7 @@ registry.register({
     type: 'SingleSelector',
     displayName: '单选(selector)',
     input: SingleSelector,
-    builder: SingleSelector,
+    builder: SingleSelectorBuilder,
     editor: SingleSelectorOptionEditor,
     display: null,
 });
@@ -51,7 +51,7 @@ registry.register({
     type: 'SingleLineTextField',
     displayName: '单行输入(input)',
     input: SingleLineTextField,
-    builder: SingleLineTextField,
+    builder: SingleLineTextBuilder,
     editor: SingleLineTextFieldOptionEditor,
     display: null,
 });

--- a/docs/src/components/snippets/FormBuilder.tsx
+++ b/docs/src/components/snippets/FormBuilder.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import SingleSelector from '../fields/SingleSelector';
+import { SingleSelector, SingleSelectorBuilder } from '../fields/SingleSelector';
 import SingleSelectorOptionEditor from '../fields/SingleSelectorOptionEditor';
-import SingleLineTextField from '../fields/SingleLineTextField';
+import { SingleLineTextField, SingleLineTextBuilder } from '../fields/SingleLineTextField';
 import SingleLineTextFieldOptionEditor from '../fields/SingleLineTextFieldOptionEditor'
 import {
     FormBuilder,
@@ -11,7 +11,7 @@ import {
 } from 'react-dynamic-formbuilder';
 
 
-interface IProps {}
+interface IProps { }
 
 interface IState {
     fields: IField[],
@@ -32,7 +32,7 @@ registry.register({
     type: 'SingleSelector',
     displayName: '单选(selector)',
     input: SingleSelector,
-    builder: SingleSelector,
+    builder: SingleSelectorBuilder,
     editor: SingleSelectorOptionEditor,
     display: null,
 });
@@ -51,7 +51,7 @@ registry.register({
     type: 'SingleLineTextField',
     displayName: '单行输入(input)',
     input: SingleLineTextField,
-    builder: SingleLineTextField,
+    builder: SingleLineTextBuilder,
     editor: SingleLineTextFieldOptionEditor,
     display: null,
 });
@@ -89,11 +89,11 @@ export default class extends React.Component<IProps, IState> {
 
     private onFieldEditing(field: IField) {
         // Do nothing for this example
-        this.setState({field} as IState);
+        this.setState({ field } as IState);
     }
 
     private onChangeFields(fields: IField[]) {
-        this.setState({fields} as IState)
+        this.setState({ fields } as IState)
     }
 
     render() {
@@ -107,7 +107,7 @@ export default class extends React.Component<IProps, IState> {
                 registry={registry}
                 onFieldEditing={this.onFieldEditing}
                 onChange={this.onChangeFields}
-                fields={this.state.fields}/>
+                fields={this.state.fields} />
         );
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-formbuilder",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "repository": "teamious/FormBuilder",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/components/FieldBuilderWrapper.tsx
+++ b/src/components/FieldBuilderWrapper.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+import { FormBuilderDraggable as Draggable } from './FormBuilderDraggable';
+import { FormBuilderEditable as Editable } from './FormBuilderEditable';
+import { FormBuilderDroppable as Droppable } from './FormBuilderDroppable';
+import * as data from '../data';
+
+export interface FieldBuilderCreator {
+    (FieldBuilder: data.IFieldBuilderComponent): React.ComponentClass<data.IFieldBuilderProps>
+}
+
+export function createFieldBuilderWrapper(): FieldBuilderCreator {
+    return (FieldBuilder: data.IFieldBuilderComponent) => {
+        return class FieldBuilderWrapper extends React.PureComponent<data.IFieldBuilderWrapperProps, void> {
+            public render() {
+                const isEditing = (this.props.field.id === this.props.editingFieldId);
+                const {onDrop, onEditField, onDeleteField, ...builderProps} = this.props; 
+                return (
+                    <Droppable
+                        canDrop={this.props.canDrop}
+                        index={this.props.index}
+                        onDrop={onDrop}
+                        field={this.props.field}
+                    >
+                        <Editable
+                            deleteButton={this.props.deleteButton}
+                            showDeleteButton
+                            editButton={this.props.editButton}
+                            onEdit={onEditField}
+                            onDelete={onDeleteField}
+                            index={this.props.index}
+                            field={this.props.field}
+                            isEditing={isEditing}
+                        >
+                            <Draggable
+                                canDrag={this.props.canDrag}
+                                index={this.props.index}
+                                field={this.props.field}
+                            >
+                                <FieldBuilder {...builderProps} />
+                            </Draggable>
+                        </Editable>
+                    </Droppable>
+                )
+            }
+        }
+    }
+}

--- a/src/components/FormBuilder.tsx
+++ b/src/components/FormBuilder.tsx
@@ -206,7 +206,7 @@ export class FormBuilder extends React.Component<IFormBuilderProps, {}> {
             return;
         }
 
-        const fieldBuilderProps: data.IFieldBuilderProps = {
+        const fieldBuilderProps: data.IFieldBuilderWrapperProps = {
             field,
             index,
             registry: this.props.registry,
@@ -220,40 +220,16 @@ export class FormBuilder extends React.Component<IFormBuilderProps, {}> {
             onBeforeAddField: this.props.onBeforeAddField,
             canDrag: this.props.canDrag,
             canDrop: this.props.canDrop,
+
+            onDeleteField: this.onDeleteField,
+            onDrop: this.onDrop,
+            onEditField: this.onEditField
         }
 
         const component = React.createElement(fieldDef.builder, fieldBuilderProps);
-
-        const isEditing = (field.id === this.props.editingFieldId);
-        const allowDelete = !field.isSystemField;
-
         return (
             <div className='form-builder-field' key={field.id}>
-                <Droppable
-                    canDrop={this.props.canDrop}
-                    index={index}
-                    onDrop={this.onDrop}
-                    field={field}
-                >
-                    <Editable
-                        deleteButton={this.props.deleteButton}
-                        showDeleteButton={allowDelete}
-                        editButton={this.props.editButton}
-                        onEdit={this.onEditField}
-                        onDelete={this.onDeleteField}
-                        index={index}
-                        field={field}
-                        isEditing={isEditing}
-                    >
-                        <Draggable
-                            canDrag={this.props.canDrag}
-                            index={index}
-                            field={field}
-                        >
-                            {component}
-                        </Draggable>
-                    </Editable>
-                </Droppable>
+                {component}
             </div>
         )
     }

--- a/src/components/NestedForm/NestedFormBuilder.tsx
+++ b/src/components/NestedForm/NestedFormBuilder.tsx
@@ -60,4 +60,4 @@ export class NestedFormBuilder extends React.PureComponent<data.IFieldBuilderPro
     }
 }
 
-export const NestedFormBuilderWrapper = createFieldBuilderWrapper()(NestedFormBuilder);
+export const NestedFormBuilderWrapper: React.ComponentClass<data.IFieldBuilderProps> = createFieldBuilderWrapper()(NestedFormBuilder);

--- a/src/components/NestedForm/NestedFormBuilder.tsx
+++ b/src/components/NestedForm/NestedFormBuilder.tsx
@@ -4,6 +4,7 @@ import * as assign from 'object-assign';
 import * as data from '../../data';
 import { NestedForm } from '.'
 import { FormBuilder } from '../FormBuilder';
+import { createFieldBuilderWrapper } from '../FieldBuilderWrapper';
 
 export class NestedFormBuilder extends React.PureComponent<data.IFieldBuilderProps, {}> {
     constructor() {
@@ -58,3 +59,5 @@ export class NestedFormBuilder extends React.PureComponent<data.IFieldBuilderPro
         )
     }
 }
+
+export const NestedFormBuilderWrapper = createFieldBuilderWrapper()(NestedFormBuilder);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,8 @@
+export * from './FieldBuilderWrapper';
+export * from './FormBuilderDraggable';
+export * from './FormBuilderDroppable';
+export * from './FormBuilderEditable';
+
 export * from './FieldOptionEditor';
 export * from './FieldSelector';
 export * from './FormBuilder';

--- a/src/data/IFieldBuilder.ts
+++ b/src/data/IFieldBuilder.ts
@@ -4,6 +4,7 @@ import { FieldRegistry } from './FieldRegistry';
 import { IEditableControlSource } from './IEditableControlSource';
 import { IFieldChange } from './IFieldChange';
 import { IFieldState } from './IFormState';
+import { IDropTargetItem, IDragSourceItem} from './IDragDrop';
 
 export interface IFieldBuilderProps {
     field: IField;
@@ -19,6 +20,12 @@ export interface IFieldBuilderProps {
     onError: (field: IField, index: number, error: any) => void;
     canDrag?: (field: IField) => boolean;
     canDrop?: (source: IField, target?: IField) => boolean;
+}
+
+export interface IFieldBuilderWrapperProps extends IFieldBuilderProps {
+    onDrop: (target: IDropTargetItem, source: IDragSourceItem, didDrop: boolean) => void;
+    onEditField: (field: IField) => void;
+    onDeleteField: (index: number) => void;
 }
 
 export interface IGenericFieldBuilderProps<T extends IField> extends IFieldBuilderProps {


### PR DESCRIPTION
FieldBuilder now will take full control of rendering builder, which includes editable, dropable, dragable. We provide the helper method - 'createFieldBuilderWrapper' to create default Editable/Dropable/Dragable experience.

In this way, it provides a way to customize field own builder experience. You can create your own editable/dropable/dragable experience.