### PR TITLE
Move injector logic into registry

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "react": "15.4.1",
     "react-bootstrap": "^0.30.8",
     "react-dom": "15.4.1",
-    "react-dynamic-formbuilder": "^1.0.40",
+    "react-dynamic-formbuilder": "^1.0.55",
     "react-router": "^4.0.0",
     "react-router-dom": "^4.0.0",
     "sass-loader": "^6.0.3",

--- a/docs/src/components/fields/SingleLineField.ts
+++ b/docs/src/components/fields/SingleLineField.ts
@@ -1,4 +1,4 @@
-import { IField, IFieldDef } from 'react-dynamic-formbuilder';
+import { IField, IFieldDef, IFieldState, IFieldInputInjector } from 'react-dynamic-formbuilder';
 import { SingleLineTextField, SingleLineTextBuilder } from './SingleLineTextField';
 import KeyValueDisplay from './KeyValueDisplay';
 import SingleLineTextFieldOptionEditor from './SingleLineTextFieldOptionEditor';
@@ -14,12 +14,22 @@ const Field: IField = {
     }
 };
 
+function onValuesChanged(field: IField, values: { [id: string]: any; }): IFieldState {
+    console.log('onValuesChanged', field, values);
+    return null;
+}
+
+const inputInjector: IFieldInputInjector = {
+    onValuesChanged: onValuesChanged
+}
+
 export const SingleLineField: IFieldDef = {
     type: Type,
     field: Field,
     displayName: '单行输入(input)',
     builder: SingleLineTextBuilder,
     input: SingleLineTextField,
+    inputInjector: inputInjector,
     display: KeyValueDisplay,
     editor: SingleLineTextFieldOptionEditor,
 };

--- a/docs/src/components/fields/SingleLineTextField.tsx
+++ b/docs/src/components/fields/SingleLineTextField.tsx
@@ -2,10 +2,7 @@ import * as React from 'react';
 import { FormControl, FormGroup, ControlLabel, Col } from 'react-bootstrap';
 import { IField, IFieldBuilderProps, IFieldInputProps, IFieldInputInjector, createFieldBuilderWrapper } from 'react-dynamic-formbuilder';
 
-interface IState {
-}
-
-export class SingleLineTextField extends React.PureComponent<IFieldInputProps & IFieldBuilderProps, IState> implements IFieldInputInjector {
+export class SingleLineTextField extends React.PureComponent<IFieldInputProps & IFieldBuilderProps, void> {
     public static defaultProps = {
         value: ''
     } as IFieldInputProps & IFieldBuilderProps
@@ -36,11 +33,6 @@ export class SingleLineTextField extends React.PureComponent<IFieldInputProps & 
                 </FormGroup>
             </div>
         );
-    }
-
-    public onValuesChanged(value: { [id: string]: any }): any {
-        console.log("SingleLineTextField onValuesChange", value);
-        return null;
     }
 
     private onTextFieldChange(event: any) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-formbuilder",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "repository": "teamious/FormBuilder",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -25,7 +25,6 @@ export class FormInput extends React.PureComponent<IFormInputProps, {}> {
     // The status of the current form input component.
     // The status is internal state of form input.
     private formState: data.IFormState;
-    private fieldInputs: { [index: string]: any } = {};
 
     public static defaultProps: Partial<IFormInputProps> = {
         value: {}
@@ -54,9 +53,6 @@ export class FormInput extends React.PureComponent<IFormInputProps, {}> {
             context: this.props.context,
             attempt: this.props.attempt,
             onValueChange: this.onValueChanged,
-            ref: (input: any) => {
-                this.fieldInputs[index] = input
-            }
         };
 
         const component = React.createElement(fieldDef.input, fieldInputProps);
@@ -85,9 +81,9 @@ export class FormInput extends React.PureComponent<IFormInputProps, {}> {
 
     private fireValuesChange(value: any) {
         this.props.fields.forEach((field, index) => {
-            const input = this.fieldInputs[index];
-            if (input && input.onValuesChanged) {
-                const fieldState = input.onValuesChanged(value);
+            const fieldDef = this.props.registry[field.type] as data.IFieldDef;
+            if (fieldDef && fieldDef.inputInjector && fieldDef.inputInjector.onValuesChanged) {
+                const fieldState = fieldDef.inputInjector.onValuesChanged(field, value);
                 if (fieldState) {
                     this.formState[field.id] = fieldState;
                 }

--- a/src/data/FieldRegistry.ts
+++ b/src/data/FieldRegistry.ts
@@ -1,7 +1,7 @@
 import { IField } from './IField';
 import { IFieldBuilderComponent } from './IFieldBuilder';
 import { IFieldOptionEditorComponent } from './IFieldOptionEditor';
-import { IFieldInputComponent } from './IFieldInput';
+import { IFieldInputComponent, IFieldInputInjector } from './IFieldInput';
 import { IFieldDisplayComponent } from './IFieldDisplay';
 import { IFieldSelectorComponent } from './IFieldSelector';
 
@@ -11,6 +11,7 @@ export interface IFieldDef {
     field: IField;
     builder: IFieldBuilderComponent;
     input: IFieldInputComponent;
+    inputInjector?: IFieldInputInjector;
     display: IFieldDisplayComponent;
     editor?: IFieldOptionEditorComponent;
     selector?: IFieldSelectorComponent;

--- a/src/data/IFieldInput.ts
+++ b/src/data/IFieldInput.ts
@@ -31,5 +31,5 @@ export interface IFieldInputInjector {
     // The event will be triggered when form values has been changed.
     // The corresponding values update can be preformed here.
     // Don't call onValueChange inside of this method.
-    onValuesChanged?: (values: { [id: string]: any }) => IFieldState;
+    onValuesChanged?: (field: IField, values: { [id: string]: any }) => IFieldState;
 }


### PR DESCRIPTION
1. Before Injector lives in the component, which makes injector work only after render().
2. Injector logic doesn't depend on component.

Some discussion below.
Injector is to inject the business logic into form life cycle. No rendering experience required. The current injector is decouple withe component.

If there is a need to render view change in the injector, how can we achieve that?
Still use Injector to update the data value, which will cause re-rendering. And we need to pass the data value into FieldComponent to reflect the value change.
